### PR TITLE
Add custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./404.style.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/favicon.ico">
+
+  <title>ページが見つかりません | コピペでQR読み取りくん</title>
+  <meta name="description" content="お探しのページは見つかりませんでした。トップページからコピペでQR読み取りくんをご利用ください。">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@450&display=swap" as="style">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@450&display=swap">
+
+  <meta property="og:url" content="https://yomitorikun.hirokiwa.com/404" />
+  <meta property="og:type" content="website" />
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="ページが見つかりません | コピペでQR読み取りくん" />
+  <meta property="og:description" content="お探しのページは見つかりませんでした。トップページからコピペでQR読み取りくんをご利用ください。" />
+  <meta property="og:site_name" content="コピペでQR読み取りくん" />
+  <meta property="og:image"
+    content="https://github-production-user-asset-6210df.s3.amazonaws.com/89170014/275133791-23c5e55f-afea-40d1-9d24-b43e4738dd22.png" />
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:alt" content="コピペでQR読み取りくん">
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:creator" content="@hirokiwasan" />
+  <meta name="twitter:title" content="ページが見つかりません | コピペでQR読み取りくん">
+  <meta name="twitter:description" content="お探しのページは見つかりませんでした。トップページからコピペでQR読み取りくんをご利用ください。" />
+  <meta name="twitter:image"
+    content="https://github-production-user-asset-6210df.s3.amazonaws.com/89170014/275133791-23c5e55f-afea-40d1-9d24-b43e4738dd22.png" />
+  <meta name="twitter:image:type" content="image/jpeg">
+  <meta name="twitter:image:alt" content="コピペでQR読み取りくん">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JWLNCNBNLF"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-JWLNCNBNLF');
+  </script>
+</head>
+
+<body class="body">
+  <header class="header">
+    <a href="/" class="titleLink" title="トップページを読み込む">
+      <div class="titleLinkInner">
+        <img src="/logo.png" alt="アイコン" class="iconImage">
+        <h1 class="title">コピペでQR読み取りくん</h1>
+      </div>
+    </a>
+  </header>
+
+  <main class="not-found" aria-labelledby="not-found-title">
+    <p class="not-found__status">404</p>
+    <h2 id="not-found-title" class="not-found__title">
+      <span class="not-found__title-part">うわ！</span>
+      <span class="not-found__title-part">ページが見つからない！</span>
+    </h2>
+    <p class="not-found__message">
+      <span class="not-found__message-part">URLが間違っているか、</span>
+      <span class="not-found__message-part">ページが移動または削除された</span>
+      <span class="not-found__message-part">可能性があります。</span>
+    </p>
+    <p class="not-found__message"></p>
+      <span class="not-found__message-part">トップページからQRコードの読み取りを</span>
+      <span class="not-found__message-part">お試しください。</span>
+    </p>
+    <a href="/" class="not-found__button">
+      <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24" aria-hidden="true" focusable="false">
+        <path d="M240-200h120v-240h240v240h120v-360L480-740 240-560v360Zm-80 80v-480l320-240 320 240v480H520v-240h-80v240H160Zm320-350Z" />
+      </svg>
+      <span>トップページへ戻る</span>
+    </a>
+  </main>
+
+  <footer class="footer">
+    <nav class="footer__nav" aria-label="フッターナビゲーション">
+      <ul class="footer__list">
+        <li class="footer-link-list__item">
+          <a href="/privacy" class="link-item">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 -960 960 960" aria-hidden="true"
+              focusable="false" fill="#707070">
+              <path
+                d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-139-35-229.5-159.5T160-516v-244l320-120 320 120v244q0 152-90.5 276.5T480-80Zm0-84q104-33 172-132t68-220v-189l-240-90-240 90v189q0 121 68 220t172 132Zm0-316Z" />
+            </svg>
+            <span class="link-item__text">プライバシーポリシー</span>
+          </a>
+        </li>
+        <li class="footer-link-list__item">
+          <a href="/contact" class="link-item">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 -960 960 960" aria-hidden="true"
+              focusable="false" fill="#707070">
+              <path
+                d="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm320-280L160-640v400h640v-400L480-440Zm0-80 320-200H160l320 200ZM160-640v-80 480-400Z" />
+            </svg>
+            <span class="link-item__text">お問い合わせ</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+
+    <small class="footer-copyright">
+      <span class="footer-copyright__service-name">コピペでQR読み取りくん</span>
+      <span class="footer-copyright__meta">
+        <span class="footer-copyright__symbol" aria-label="著作権">©</span>
+        <span class="footer-copyright__owner">hiroki</span>
+        <time class="footer-copyright__year" datetime="2023">2023</time>
+      </span>
+    </small>
+  </footer>
+</body>
+
+</html>

--- a/404.style.css
+++ b/404.style.css
@@ -1,0 +1,57 @@
+.not-found {
+  box-sizing: border-box;
+  width: min(100%, 48rem);
+  margin: 0 auto;
+  padding: 6rem 1.5rem;
+  text-align: center;
+}
+
+.not-found__status {
+  margin: 0;
+  color: #4f4f4f;
+  font-size: clamp(5rem, 18vw, 10rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.not-found__title {
+  margin: 1rem 0 0;
+  color: #4f4f4f;
+  font-size: clamp(1.75rem, 5vw, 2.75rem);
+}
+
+.not-found__title-part {
+  display: inline-block;
+}
+
+.not-found__message {
+  margin: 1.5rem auto 0;
+  max-width: 36rem;
+  line-height: 1.8;
+}
+
+.not-found__message-part {
+  display: inline-block;
+}
+
+.not-found__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 2rem;
+  padding: 0.85rem 1.5rem;
+  color: #4f4f4f;
+  font-weight: bold;
+  text-decoration: none;
+  background-color: #9bf5d5;
+  border-radius: 0.5em;
+}
+
+.not-found__button svg {
+  fill: currentColor;
+}
+
+.not-found__button:hover,
+.not-found__button:focus {
+  background-color: #c9feec;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,6 +32,7 @@ export default defineConfig({
         main: resolve(__dirname, 'index.html'),
         contact: resolve(__dirname, 'contact.html'),
         privacy: resolve(__dirname, 'privacy.html'),
+        notFound: resolve(__dirname, '404.html'),
       },
     },
   },


### PR DESCRIPTION
### Motivation
- Provide a user-friendly branded Japanese 404 page that uses the site header/footer and metadata so visitors hitting missing URLs get a clear recovery path.
- Ensure the 404 page is included in the static build so `dist/404.html` is emitted and can be served by static hosts.

### Description
- Add a new `404.html` implementing a localized 404 message, shared header/footer, OG/Twitter metadata, and a CTA link back to the top page.
- Add responsive styles for the 404 layout and controls to `style.css` under the `.not-found` family of selectors to match the existing site palette.
- Add the `404.html` entry to Vite's multi-page build `input` in `vite.config.js` (named `notFound`) so it is produced during `vite build`.

### Testing
- Ran `npm run build`, which completed successfully and produced `dist/404.html` as part of the build artifacts.
- Started the dev server with `npm run dev -- --host 127.0.0.1`, and Vite reported the server ready (local URL shown).
- Attempted to capture a screenshot with Playwright to validate rendering, but the attempt failed because `playwright` is not installed in the environment (test aborted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45cd98cb7c832fb90c9766d94f9d38)